### PR TITLE
Fix NumPy float32 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ python:
 install:
   - pip install six blist unittest2 pytz
   - pip install -e .
-script: python tests/tests.py
+script:
+  - python tests/tests.py
+  - python tests/test_numpy_handling.py

--- a/tests/test_numpy_handling.py
+++ b/tests/test_numpy_handling.py
@@ -1,0 +1,31 @@
+# coding=UTF-8
+from __future__ import print_function, unicode_literals
+
+import numpy as np
+import six
+
+import nujson
+
+if six.PY2:
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class nujsonValidatingNumpy(unittest.TestCase):
+
+    def test_np_int64(self):
+        d = {
+            "a": np.int64(1)
+        }
+        self.assertEqual(nujson.dumps(d), '{"a":1}')
+
+    def test_np_float32(self):
+        d = {
+            "a": np.float32(1.2)
+        }
+        self.assertEqual(nujson.dumps(d), '{"a":1.2}')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I find float32 error in [Fix OverflowError when encoding numpy arrays by mthh · Pull Request #229 · esnme/ultrajson · GitHub](https://github.com/esnme/ultrajson/pull/229#issuecomment-244425536)

```python
import nujson
import numpy as np
res = nujson.dumps(np.array([1.1, 2.2], dtype=np.float32))
print(res)
# [1,2]
```

This PR try to fix it.