### PR TITLE
Update Python versions and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "2.7"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   - pip install six blist unittest2 pytz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: xenia
-sudo: false
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 
 install:
   - pip install six blist unittest2 pytz

--- a/setup.py
+++ b/setup.py
@@ -94,5 +94,6 @@ setup(name='nujson',
       license="BSD License",
       platforms=['any'],
       url="https://caiyunapp.com",
+      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
       classifiers=CLASSIFIERS,
       )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 """.splitlines()))
 
 try:


### PR DESCRIPTION
* Add support for Python 3.8
* Test on 3.9-dev to avoid surprises, the full release is out in October
* Xenial is the default on Travis CI (it had a typo anyway)
* `sudo` no longer has any effect https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
* Cache pip on the CI to speed up builds
