### PR TITLE
Fix DeprecationWarning: Please use assertEqual instead

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -696,7 +696,7 @@ class UltraJSONTests(unittest.TestCase):
 
         output = ujson.encode(ObjectTest())
         dec = ujson.decode(output)
-        self.assertEquals(dec, {})
+        self.assertEqual(dec, {})
 
     def test_toDict(self):
         d = {"key": 31337}


### PR DESCRIPTION
Fixes:
```
tests/tests.py:699: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(dec, {})
```
https://travis-ci.org/caiyunapp/ultrajson/jobs/626009361#L227

